### PR TITLE
Add MTPLX benchmark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Vault - View model details, unload, and Pull models directly for Ollama
 |---------|------|--------------|-------|
 | **Apple Intelligence** | On-device (Foundation Models) | — | macOS 26+ with Apple Intelligence enabled. No setup; appears in the backend menu when supported. |
 | **Ollama** | Native support | 11434 | Install from [ollama.com](https://ollama.com) - auto-detected on launch |
+| **MTPLX** | OpenAI-compatible + native timing | 8000 | `brew install youssofal/mtplx/mtplx && mtplx serve --port 8000` |
 | **LM Studio** | OpenAI-compatible | 1234 | Enable local server in LM Studio settings |
 | **mlx-lm** | OpenAI-compatible | 8080 | `pip install mlx-lm && mlx_lm.server --model <model>` |
 | **vLLM** | OpenAI-compatible | 8000 | Add in Settings |
@@ -333,7 +334,7 @@ Anubis captures Apple Silicon telemetry during inference via IOReport and system
 Anubis automatically detects which process is serving your model:
 
 - **Port-based detection**: Uses `lsof` to find the PID listening on the inference port (called once per benchmark start)
-- **Backend identification**: Matches process path and command-line args to identify Ollama, LM Studio, mlx-lm, vLLM, LocalAI, llama.cpp
+- **Backend identification**: Matches process path and command-line args to identify Ollama, MTPLX, LM Studio, mlx-lm, vLLM, LocalAI, llama.cpp
 - **Memory accounting**: Uses `phys_footprint` (same as Activity Monitor) which includes Metal/GPU buffer allocations - critical for MLX and other GPU-accelerated backends
 - **LM Studio support**: Walks Electron app bundle descendants to find the model-serving process
 - **Manual override**: Process picker lets you select any process by name, sorted by memory usage

--- a/anubis/anubis/App/ContentView.swift
+++ b/anubis/anubis/App/ContentView.swift
@@ -643,7 +643,7 @@ struct SettingsView: View {
             } header: {
                 Text("OpenAI-Compatible Servers")
             } footer: {
-                Text("Add servers that support the OpenAI API format (LM Studio, LocalAI, vLLM, etc.)")
+                Text("Add servers that support the OpenAI API format (MTPLX, LM Studio, LocalAI, vLLM, etc.)")
             }
 
             // Actions

--- a/anubis/anubis/Features/Arena/ArenaViewModel.swift
+++ b/anubis/anubis/Features/Arena/ArenaViewModel.swift
@@ -441,7 +441,9 @@ final class ArenaViewModel: ObservableObject {
         if backend == .ollama { return true }
         if backend == .openai {
             if openAIConfig?.id == BackendConfiguration.defaultOMLX.id { return true }
-            if let owner = model?.ownedBy?.lowercased(), owner.contains("omlx") { return true }
+            if openAIConfig?.id == BackendConfiguration.defaultMTPLX.id { return true }
+            if let owner = model?.ownedBy?.lowercased(),
+               owner.contains("omlx") || owner.contains("mtplx") { return true }
         }
         return false
     }

--- a/anubis/anubis/Features/Benchmark/BenchmarkView.swift
+++ b/anubis/anubis/Features/Benchmark/BenchmarkView.swift
@@ -1148,7 +1148,7 @@ struct BenchmarkView: View {
         }
     }
 
-    /// Effective Session Details source: default to oMLX's own metrics whenever
+    /// Effective Session Details source: default to the backend's own metrics whenever
     /// the run has them; respect the user's explicit choice once they make one.
     private var showServerReportedDetails: Bool {
         detailsSourceOverride ?? hasServerReportedMetrics
@@ -1170,7 +1170,7 @@ struct BenchmarkView: View {
                 }
             }
 
-            // oMLX reports its own metrics — let the user swap the grid to the
+            // A supported server reports its own metrics — let the user swap the grid to the
             // server's verbatim figures, marked as server-verified.
             if hasServerReportedMetrics {
                 HStack(spacing: 6) {
@@ -1178,7 +1178,7 @@ struct BenchmarkView: View {
                         Image(systemName: "checkmark.seal.fill")
                             .font(.caption2)
                             .foregroundStyle(.green)
-                        Text("Reported directly by the oMLX server")
+                        Text("Reported directly by the \(serverReportedSourceName) server")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
@@ -1188,7 +1188,7 @@ struct BenchmarkView: View {
                         set: { detailsSourceOverride = $0 }
                     )) {
                         Text("Anubis").tag(false)
-                        Text("oMLX").tag(true)
+                        Text(serverReportedSourceName).tag(true)
                     }
                     .pickerStyle(.segmented)
                     .controlSize(.small)
@@ -1219,8 +1219,7 @@ struct BenchmarkView: View {
         }
     }
 
-    /// The current session's oMLX-reported `usage` block, parsed. nil unless
-    /// the run was against a server that reports its own metrics (oMLX).
+    /// The current session's backend-reported metrics, parsed.
     private var currentServerMetrics: [String: Any]? {
         guard let json = viewModel.currentSession?.serverMetricsJSON,
               let data = json.data(using: .utf8),
@@ -1231,25 +1230,35 @@ struct BenchmarkView: View {
 
     private var hasServerReportedMetrics: Bool { currentServerMetrics != nil }
 
-    /// Session Details grid built straight from oMLX's reported usage block —
+    private var serverReportedSourceName: String {
+        currentServerMetrics?["decode_tok_s"] != nil ? "MTPLX" : "oMLX"
+    }
+
+    /// Session Details grid built straight from the backend's reported metrics —
     /// every value is the server's own number, not Anubis-derived.
     private func serverReportedStatsGrid(_ m: [String: Any]) -> some View {
         func dbl(_ key: String) -> Double? { (m[key] as? NSNumber)?.doubleValue }
         func intVal(_ key: String) -> Int? { (m[key] as? NSNumber)?.intValue }
+        func firstDouble(_ keys: String...) -> Double? {
+            keys.lazy.compactMap { dbl($0) }.first
+        }
         let cached = ((m["prompt_tokens_details"] as? [String: Any])?["cached_tokens"] as? NSNumber)?.intValue
+            ?? intVal("cached_tokens")
+        let totalTokens = intVal("total_tokens")
+            ?? (intVal("prompt_tokens").map { $0 + (intVal("completion_tokens") ?? 0) })
 
         return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: Spacing.sm), count: 6), spacing: Spacing.xs) {
-            serverCell("Prefill Speed", dbl("prompt_tokens_per_second").map { String(format: "%.2f tok/s", $0) })
-            serverCell("Generation Speed", dbl("generation_tokens_per_second").map { String(format: "%.2f tok/s", $0) })
-            serverCell("Time to First Token", dbl("time_to_first_token").map { String(format: "%.2fs", $0) })
-            serverCell("Total Time", dbl("total_time").map { String(format: "%.2fs", $0) })
-            serverCell("Prompt Eval", dbl("prompt_eval_duration").map { String(format: "%.2fs", $0) })
-            serverCell("Generation", dbl("generation_duration").map { String(format: "%.2fs", $0) })
+            serverCell("Prefill Speed", firstDouble("prompt_tokens_per_second", "prompt_tps", "prefill_tok_s").map { String(format: "%.2f tok/s", $0) })
+            serverCell("Generation Speed", firstDouble("generation_tokens_per_second", "decode_tok_s").map { String(format: "%.2f tok/s", $0) })
+            serverCell("Time to First Token", firstDouble("time_to_first_token", "ttft_s").map { String(format: "%.2fs", $0) })
+            serverCell("Total Time", firstDouble("total_time", "request_elapsed_s", "elapsed_s").map { String(format: "%.2fs", $0) })
+            serverCell("Prompt Eval", firstDouble("prompt_eval_duration", "prompt_eval_time_s").map { String(format: "%.2fs", $0) })
+            serverCell("Generation", firstDouble("generation_duration", "decode_elapsed_s").map { String(format: "%.2fs", $0) })
             serverCell("Model Load", dbl("model_load_duration").map { String(format: "%.2fs", $0) })
             serverCell("Cached Tokens", cached.map { "\($0)" })
             serverCell("Prompt Tokens", intVal("prompt_tokens").map { "\($0)" })
             serverCell("Completion Tokens", intVal("completion_tokens").map { "\($0)" })
-            serverCell("Total Tokens", intVal("total_tokens").map { "\($0)" })
+            serverCell("Total Tokens", totalTokens.map { "\($0)" })
         }
     }
 
@@ -1468,13 +1477,13 @@ private struct InferenceStatsButton: View {
                 }
             }
 
-            // oMLX reports its own metrics; show them verbatim, exactly as the
+            // Supported servers report their own metrics; show them verbatim, exactly as the
             // server sent them (including fields we don't otherwise surface).
-            let serverRows = omlxReportedRows
+            let serverRows = serverReportedRows
             if !serverRows.isEmpty {
                 Divider()
                     .padding(.vertical, 3)
-                Text("Reported by oMLX")
+                Text("Reported by \(serverReportedSourceName)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.bottom, 2)
@@ -1487,9 +1496,14 @@ private struct InferenceStatsButton: View {
         .frame(width: 260)
     }
 
-    /// Parse the backend's raw `usage` JSON (oMLX) into flat label/value rows,
+    private var serverReportedSourceName: String {
+        guard let json = session.serverMetricsJSON else { return "server" }
+        return json.contains("\"decode_tok_s\"") ? "MTPLX" : "oMLX"
+    }
+
+    /// Parse the backend's raw metrics JSON into flat label/value rows,
     /// preserving the server's own numbers without rounding or renaming.
-    private var omlxReportedRows: [(label: String, value: String)] {
+    private var serverReportedRows: [(label: String, value: String)] {
         guard let json = session.serverMetricsJSON,
               let data = json.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/anubis/anubis/Features/Benchmark/BenchmarkViewModel.swift
+++ b/anubis/anubis/Features/Benchmark/BenchmarkViewModel.swift
@@ -300,17 +300,34 @@ final class BenchmarkViewModel: ObservableObject {
     /// Guards against another OpenAI-compatible server on the oMLX port being
     /// mistaken for the real thing.
     var isVerifiedOMLX: Bool {
-        if currentSession?.serverMetricsJSON != nil { return true }
         if let owner = selectedModel?.ownedBy?.lowercased(), owner.contains("omlx") { return true }
+        // oMLX metrics are stored from its extended `usage` object. MTPLX now
+        // also stores server metrics, but under a distinct `mtplx_stats`
+        // schema, so the mere presence of JSON is no longer an oMLX signal.
+        if let json = currentSession?.serverMetricsJSON {
+            return json.contains("\"generation_tokens_per_second\"")
+                || json.contains("\"generation_duration\"")
+        }
         return false
     }
 
+    /// True for the stock MTPLX connection or a server positively identified
+    /// by its `/v1/models` `owned_by` fingerprint.
+    var isMTPLXBackend: Bool {
+        guard selectedBackend == .openai else { return false }
+        if inferenceService.currentOpenAIConfig?.id == BackendConfiguration.defaultMTPLX.id {
+            return true
+        }
+        return selectedModel?.ownedBy?.lowercased().contains("mtplx") == true
+    }
+
     /// Whether the current backend exposes a thinking toggle. Ollama uses the
-    /// `think` request field; oMLX uses `chat_template_kwargs.enable_thinking`.
+    /// `think` request field; oMLX uses `chat_template_kwargs.enable_thinking`;
+    /// MTPLX uses the top-level `enable_thinking` field.
     /// Other OpenAI-compatible servers (LM Studio, vLLM, plain mlx-lm) don't,
     /// so the picker stays hidden and the mode stays Auto for them.
     var supportsThinkingToggle: Bool {
-        selectedBackend == .ollama || isBuiltInOMLXBackend || isVerifiedOMLX
+        selectedBackend == .ollama || isBuiltInOMLXBackend || isVerifiedOMLX || isMTPLXBackend
     }
 
     /// Whether the selected model can be ejected (unloaded) from here. Both

--- a/anubis/anubis/Features/Benchmark/SessionHistoryView.swift
+++ b/anubis/anubis/Features/Benchmark/SessionHistoryView.swift
@@ -544,7 +544,7 @@ struct SessionDetailView: View {
     @ObservedObject var viewModel: BenchmarkViewModel
     @State private var samples: [BenchmarkSample] = []
     @State private var statistics: SampleStatistics?
-    /// Session Details source override (oMLX runs only). nil = default to the
+    /// Session Details source override (runs with server metrics only). nil = default to the
     /// server's own metrics; once toggled it sticks. See BenchmarkView.
     @State private var detailsSourceOverride: Bool? = nil
 
@@ -606,15 +606,15 @@ struct SessionDetailView: View {
 
     private var statsSection: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            // oMLX runs carry the server's own metrics — let the user swap to
-            // the verbatim server-reported figures (defaults to oMLX).
+            // Some servers carry their own metrics — let the user swap to
+            // the verbatim server-reported figures.
             if hasServerReportedMetrics {
                 HStack(spacing: 6) {
                     if showServerReportedDetails {
                         Image(systemName: "checkmark.seal.fill")
                             .font(.caption2)
                             .foregroundStyle(.green)
-                        Text("Reported directly by the oMLX server")
+                        Text("Reported directly by the \(serverReportedSourceName) server")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
@@ -624,7 +624,7 @@ struct SessionDetailView: View {
                         set: { detailsSourceOverride = $0 }
                     )) {
                         Text("Anubis").tag(false)
-                        Text("oMLX").tag(true)
+                        Text(serverReportedSourceName).tag(true)
                     }
                     .pickerStyle(.segmented)
                     .labelsHidden()
@@ -640,7 +640,7 @@ struct SessionDetailView: View {
         }
     }
 
-    /// oMLX's reported `usage` block, parsed. nil for non-oMLX sessions.
+    /// The backend's reported metrics, parsed. nil when none were supplied.
     private var currentServerMetrics: [String: Any]? {
         guard let json = session.serverMetricsJSON,
               let data = json.data(using: .utf8),
@@ -651,29 +651,39 @@ struct SessionDetailView: View {
 
     private var hasServerReportedMetrics: Bool { currentServerMetrics != nil }
 
+    private var serverReportedSourceName: String {
+        currentServerMetrics?["decode_tok_s"] != nil ? "MTPLX" : "oMLX"
+    }
+
     private var showServerReportedDetails: Bool {
         detailsSourceOverride ?? hasServerReportedMetrics
     }
 
-    /// Stats grid built straight from oMLX's reported usage — every value is
+    /// Stats grid built straight from the backend's reported metrics — every value is
     /// the server's own number, not Anubis-derived.
     private func serverReportedStatsGrid(_ m: [String: Any]) -> some View {
         func dbl(_ key: String) -> Double? { (m[key] as? NSNumber)?.doubleValue }
         func intVal(_ key: String) -> Int? { (m[key] as? NSNumber)?.intValue }
+        func firstDouble(_ keys: String...) -> Double? {
+            keys.lazy.compactMap { dbl($0) }.first
+        }
         let cached = ((m["prompt_tokens_details"] as? [String: Any])?["cached_tokens"] as? NSNumber)?.intValue
+            ?? intVal("cached_tokens")
+        let totalTokens = intVal("total_tokens")
+            ?? intVal("prompt_tokens").map { $0 + (intVal("completion_tokens") ?? 0) }
 
         return LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 4), spacing: Spacing.md) {
-            StatCell(title: "Prefill Tk/s", value: dbl("prompt_tokens_per_second").map { String(format: "%.2f tok/s", $0) } ?? "—")
-            StatCell(title: "Generation Tk/s", value: dbl("generation_tokens_per_second").map { String(format: "%.2f tok/s", $0) } ?? "—")
-            StatCell(title: "Time to First Token", value: dbl("time_to_first_token").map { String(format: "%.2fs", $0) } ?? "—")
-            StatCell(title: "Total Time", value: dbl("total_time").map { String(format: "%.2fs", $0) } ?? "—")
-            StatCell(title: "Prompt Eval", value: dbl("prompt_eval_duration").map { String(format: "%.2fs", $0) } ?? "—")
-            StatCell(title: "Generation", value: dbl("generation_duration").map { String(format: "%.2fs", $0) } ?? "—")
+            StatCell(title: "Prefill Tk/s", value: firstDouble("prompt_tokens_per_second", "prompt_tps", "prefill_tok_s").map { String(format: "%.2f tok/s", $0) } ?? "—")
+            StatCell(title: "Generation Tk/s", value: firstDouble("generation_tokens_per_second", "decode_tok_s").map { String(format: "%.2f tok/s", $0) } ?? "—")
+            StatCell(title: "Time to First Token", value: firstDouble("time_to_first_token", "ttft_s").map { String(format: "%.2fs", $0) } ?? "—")
+            StatCell(title: "Total Time", value: firstDouble("total_time", "request_elapsed_s", "elapsed_s").map { String(format: "%.2fs", $0) } ?? "—")
+            StatCell(title: "Prompt Eval", value: firstDouble("prompt_eval_duration", "prompt_eval_time_s").map { String(format: "%.2fs", $0) } ?? "—")
+            StatCell(title: "Generation", value: firstDouble("generation_duration", "decode_elapsed_s").map { String(format: "%.2fs", $0) } ?? "—")
             StatCell(title: "Model Load", value: dbl("model_load_duration").map { String(format: "%.2fs", $0) } ?? "—")
             StatCell(title: "Cached Tokens", value: cached.map { "\($0)" } ?? "—")
             StatCell(title: "Prompt Tokens", value: intVal("prompt_tokens").map { "\($0)" } ?? "—")
             StatCell(title: "Completion Tokens", value: intVal("completion_tokens").map { "\($0)" } ?? "—")
-            StatCell(title: "Total Tokens", value: intVal("total_tokens").map { "\($0)" } ?? "—")
+            StatCell(title: "Total Tokens", value: totalTokens.map { "\($0)" } ?? "—")
         }
     }
 

--- a/anubis/anubis/Integrations/OpenAICompatibleClient.swift
+++ b/anubis/anubis/Integrations/OpenAICompatibleClient.swift
@@ -67,6 +67,13 @@ struct OMLXManagedModel: Sendable, Identifiable {
     let isDefault: Bool
 }
 
+/// Server-specific request/metrics behavior discovered from the stock config
+/// or the `owned_by` fingerprint returned by `/v1/models`.
+private enum OpenAIServerFlavor {
+    case generic
+    case mtplx
+}
+
 /// Client for OpenAI-compatible API endpoints (LM Studio, LocalAI, vLLM, etc.)
 actor OpenAICompatibleClient: InferenceBackend {
     // MARK: - Properties
@@ -77,11 +84,15 @@ actor OpenAICompatibleClient: InferenceBackend {
     private let baseURL: URL
     private let session: URLSession
     private let apiKey: String?
+    private var serverFlavor: OpenAIServerFlavor
 
     // MARK: - Initialization
 
     init(configuration: BackendConfiguration) {
         self.configuration = configuration
+        self.serverFlavor = configuration.id.uuidString == "00000000-0000-0000-0000-000000000006"
+            ? .mtplx
+            : .generic
         // Strip trailing /v1 or /v1/ — Anubis appends the versioned path automatically
         var url = Constants.URLs.parse(configuration.baseURL, fallback: Constants.URLs.openAIDefault)
         let pathSuffixes = ["/v1/", "/v1"]
@@ -136,12 +147,13 @@ actor OpenAICompatibleClient: InferenceBackend {
         }
 
         do {
-            let (_, response) = try await session.data(for: request)
+            let (data, response) = try await session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 return .unhealthy(error: "Not an HTTP response")
             }
 
             if httpResponse.statusCode == 200 {
+                updateServerFlavor(fromModelsResponse: data)
                 return .healthy(version: nil)
             } else if httpResponse.statusCode == 401 {
                 return .unhealthy(error: "Authentication required")
@@ -173,6 +185,7 @@ actor OpenAICompatibleClient: InferenceBackend {
         }
 
         let modelsResponse = try JSONDecoder().decode(OpenAIModelsResponse.self, from: data)
+        updateServerFlavor(from: modelsResponse)
         let configId = configuration.id
 
         // Try to fetch richer metadata from LM Studio-style endpoint
@@ -194,13 +207,24 @@ actor OpenAICompatibleClient: InferenceBackend {
                 quantization: richMatch?.quantization ?? diskMatch?.quantization ?? parsed.quantization,
                 modelFormat: richMatch?.modelFormat ?? diskMatch?.modelFormat ?? parsed.modelFormat,
                 sizeBytes: richMatch?.sizeBytes ?? diskMatch?.sizeBytes,
-                contextLength: richMatch?.contextLength,
+                contextLength: richMatch?.contextLength ?? model.contextLength,
                 backend: .openai,
                 openAIConfigId: configId,
                 path: diskMatch?.path,
                 modifiedAt: diskMatch?.modifiedAt,
                 ownedBy: model.ownedBy
             )
+        }
+    }
+
+    private func updateServerFlavor(fromModelsResponse data: Data) {
+        guard let response = try? JSONDecoder().decode(OpenAIModelsResponse.self, from: data) else { return }
+        updateServerFlavor(from: response)
+    }
+
+    private func updateServerFlavor(from response: OpenAIModelsResponse) {
+        if response.data.contains(where: { $0.ownedBy?.lowercased().contains("mtplx") == true }) {
+            serverFlavor = .mtplx
         }
     }
 
@@ -486,14 +510,21 @@ actor OpenAICompatibleClient: InferenceBackend {
         }
         messages.append(["role": "user", "content": request.prompt])
 
-        // Translate the thinking toggle into chat_template_kwargs (oMLX/vLLM).
-        // Only sent when explicitly On/Off; Auto omits it so servers that don't
-        // understand the field are unaffected.
-        let templateKwargs: [String: Bool]?
+        // oMLX/vLLM consume the toggle in `chat_template_kwargs`; MTPLX exposes
+        // the same control as a top-level `enable_thinking` request field.
+        // Auto omits both representations so server defaults remain intact.
+        let enableThinking: Bool?
         switch request.ollamaThinkMode {
-        case .auto: templateKwargs = nil
-        case .on:   templateKwargs = ["enable_thinking": true, "preserve_thinking": false]
-        case .off:  templateKwargs = ["enable_thinking": false, "preserve_thinking": false]
+        case .auto: enableThinking = nil
+        case .on:   enableThinking = true
+        case .off:  enableThinking = false
+        }
+        let isMTPLX = serverFlavor == .mtplx
+        let templateKwargs: [String: Bool]?
+        if !isMTPLX, let enableThinking {
+            templateKwargs = ["enable_thinking": enableThinking, "preserve_thinking": false]
+        } else {
+            templateKwargs = nil
         }
 
         let body = OpenAIChatRequest(
@@ -509,7 +540,8 @@ actor OpenAICompatibleClient: InferenceBackend {
             topP: request.topP,
             stop: request.stopSequences,
             seed: request.seed,
-            chatTemplateKwargs: templateKwargs
+            chatTemplateKwargs: templateKwargs,
+            enableThinking: isMTPLX ? enableThinking : nil
         )
 
         urlRequest.httpBody = try JSONEncoder().encode(body)
@@ -547,10 +579,12 @@ actor OpenAICompatibleClient: InferenceBackend {
         var state = StreamState()
         let startTime = Date()
         var lastUsage: OpenAIUsage?
+        var lastMTPLXStats: MTPLXStats?
         // Raw usage object exactly as the backend sent it, captured only when
         // it carries oMLX's extended timing. Persisted so the UI can show
         // oMLX's numbers verbatim, including any fields we don't model yet.
         var lastUsageRawJSON: String?
+        var lastMTPLXStatsRawJSON: String?
         var finalized = false
 
         // Emit the terminal chunk exactly once. Used by both the [DONE]
@@ -558,7 +592,12 @@ actor OpenAICompatibleClient: InferenceBackend {
         func emitFinal() {
             guard !finalized else { return }
             finalized = true
-            let stats = state.finalize(startTime: startTime, usage: lastUsage, rawUsageJSON: lastUsageRawJSON)
+            let stats = state.finalize(
+                startTime: startTime,
+                usage: lastUsage,
+                mtplxStats: lastMTPLXStats,
+                rawMetricsJSON: lastMTPLXStatsRawJSON ?? lastUsageRawJSON
+            )
             continuation.yield(InferenceChunk(text: "", done: true, stats: stats))
             continuation.finish()
         }
@@ -590,6 +629,19 @@ actor OpenAICompatibleClient: InferenceBackend {
                        let usageData = try? JSONSerialization.data(withJSONObject: usageObj, options: [.sortedKeys]),
                        let usageStr = String(data: usageData, encoding: .utf8) {
                         lastUsageRawJSON = usageStr
+                    }
+                }
+
+                // MTPLX returns authoritative timing alongside standard usage
+                // in a top-level `mtplx_stats` extension on its final chunk.
+                if let mtplxStats = chunk.mtplxStats {
+                    lastMTPLXStats = mtplxStats
+                    serverFlavor = .mtplx
+                    if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let statsObj = obj["mtplx_stats"] as? [String: Any],
+                       let statsData = try? JSONSerialization.data(withJSONObject: statsObj, options: [.sortedKeys]),
+                       let statsString = String(data: statsData, encoding: .utf8) {
+                        lastMTPLXStatsRawJSON = statsString
                     }
                 }
 
@@ -748,25 +800,33 @@ private struct StreamState {
         return nil
     }
 
-    func finalize(startTime: Date, usage: OpenAIUsage?, rawUsageJSON: String? = nil) -> InferenceStats {
+    func finalize(
+        startTime: Date,
+        usage: OpenAIUsage?,
+        mtplxStats: MTPLXStats? = nil,
+        rawMetricsJSON: String? = nil
+    ) -> InferenceStats {
         let now = Date()
         let wallTotal = now.timeIntervalSince(startTime)
 
-        // Prefer the backend's own timing when it reports it (oMLX). These are
+        // Prefer the backend's own timing when it reports it (oMLX/MTPLX). These are
         // measured inside the decode loop, so they're immune to the client-read
         // bursts that make wall-clock evalDuration collapse toward zero and
         // tok/s explode (issue #25). Fall back to wall-clock for plain mlx-lm,
         // LM Studio, vLLM, llama.cpp, etc. which report only token counts.
-        let serverTiming = usage?.hasServerTiming ?? false
+        let serverTiming = (usage?.hasServerTiming ?? false) || (mtplxStats?.hasServerTiming ?? false)
 
-        let totalDuration = usage?.totalTime ?? wallTotal
-        let promptEval = usage?.promptEvalDuration
-            ?? usage?.timeToFirstToken
-            ?? firstChunkTime.map { $0.timeIntervalSince(startTime) }
-            ?? 0
-        let evalDuration = usage?.generationDuration
-            ?? firstChunkTime.map { now.timeIntervalSince($0) }
-            ?? wallTotal
+        let mtplxTotal = mtplxStats?.requestElapsed ?? mtplxStats?.elapsed
+        let totalDuration = mtplxTotal ?? usage?.totalTime ?? wallTotal
+
+        let clientPromptEval = firstChunkTime.map { $0.timeIntervalSince(startTime) } ?? 0
+        let usagePromptEval = usage?.promptEvalDuration ?? usage?.timeToFirstToken
+        let promptEval = mtplxStats?.promptEvalTime ?? usagePromptEval ?? clientPromptEval
+
+        let clientEvalDuration = firstChunkTime.map { now.timeIntervalSince($0) } ?? wallTotal
+        let evalDuration = mtplxStats?.decodeElapsed
+            ?? usage?.generationDuration
+            ?? clientEvalDuration
 
         // Reasoning duration: from first reasoning chunk to first content chunk
         // (or to end, if reasoning ran to completion without follow-on content).
@@ -806,13 +866,19 @@ private struct StreamState {
             contextLength: promptToks > 0 ? promptToks + completionToks : 0,
             reasoningTokens: reasoningTokenCount,
             reasoningDuration: reasoningDuration,
-            // oMLX hands us the exact decode-loop throughput and TTFT; use them
+            // oMLX/MTPLX hand us exact decode-loop throughput and TTFT; use them
             // verbatim so our headline numbers match the backend's own. nil for
             // every other server, which leaves tok/s/TTFT derived as before.
-            reportedTokensPerSecond: serverTiming ? usage?.generationTokensPerSecond : nil,
-            serverReportedTTFT: serverTiming ? (usage?.timeToFirstToken ?? usage?.promptEvalDuration) : nil,
-            reportedPromptTokensPerSecond: serverTiming ? usage?.promptTokensPerSecond : nil,
-            serverReportedMetricsJSON: serverTiming ? rawUsageJSON : nil
+            reportedTokensPerSecond: serverTiming
+                ? (mtplxStats?.decodeTokensPerSecond ?? usage?.generationTokensPerSecond)
+                : nil,
+            serverReportedTTFT: serverTiming
+                ? (mtplxStats?.timeToFirstToken ?? usage?.timeToFirstToken ?? usage?.promptEvalDuration)
+                : nil,
+            reportedPromptTokensPerSecond: serverTiming
+                ? (mtplxStats?.promptTokensPerSecond ?? usage?.promptTokensPerSecond)
+                : nil,
+            serverReportedMetricsJSON: serverTiming ? rawMetricsJSON : nil
         )
     }
 }
@@ -1184,10 +1250,12 @@ private struct OpenAIModel: Codable {
     let object: String?
     let created: Int?
     let ownedBy: String?
+    let contextLength: Int?
 
     enum CodingKeys: String, CodingKey {
         case id, object, created
         case ownedBy = "owned_by"
+        case contextLength = "context_length"
     }
 }
 
@@ -1205,6 +1273,8 @@ private struct OpenAIChatRequest: Codable {
     /// `enable_thinking` here to toggle a reasoning model's chain-of-thought.
     /// Omitted (nil) unless the user explicitly set thinking On/Off.
     let chatTemplateKwargs: [String: Bool]?
+    /// MTPLX's top-level thinking control. Omitted for all other servers.
+    let enableThinking: Bool?
 
     enum CodingKeys: String, CodingKey {
         case model, messages, stream, temperature, stop, seed
@@ -1212,6 +1282,7 @@ private struct OpenAIChatRequest: Codable {
         case maxTokens = "max_tokens"
         case topP = "top_p"
         case chatTemplateKwargs = "chat_template_kwargs"
+        case enableThinking = "enable_thinking"
     }
 }
 
@@ -1230,6 +1301,41 @@ private struct OpenAIChatStreamResponse: Codable {
     let model: String?
     let choices: [OpenAIStreamChoice]
     let usage: OpenAIUsage?
+    let mtplxStats: MTPLXStats?
+
+    enum CodingKeys: String, CodingKey {
+        case id, object, created, model, choices, usage
+        case mtplxStats = "mtplx_stats"
+    }
+}
+
+/// Authoritative per-request timing returned by MTPLX on the terminal SSE
+/// chunk. Field names mirror MTPLX's public `mtplx_stats` contract.
+struct MTPLXStats: Codable {
+    let elapsed: Double?
+    let requestElapsed: Double?
+    let promptEvalTime: Double?
+    let promptTPS: Double?
+    let prefillTPS: Double?
+    let timeToFirstToken: Double?
+    let decodeElapsed: Double?
+    let decodeTokensPerSecond: Double?
+
+    var promptTokensPerSecond: Double? { promptTPS ?? prefillTPS }
+    var hasServerTiming: Bool {
+        decodeElapsed != nil || decodeTokensPerSecond != nil
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case elapsed = "elapsed_s"
+        case requestElapsed = "request_elapsed_s"
+        case promptEvalTime = "prompt_eval_time_s"
+        case promptTPS = "prompt_tps"
+        case prefillTPS = "prefill_tok_s"
+        case timeToFirstToken = "ttft_s"
+        case decodeElapsed = "decode_elapsed_s"
+        case decodeTokensPerSecond = "decode_tok_s"
+    }
 }
 
 private struct OpenAIUsage: Codable {

--- a/anubis/anubis/Integrations/ProcessMonitor.swift
+++ b/anubis/anubis/Integrations/ProcessMonitor.swift
@@ -18,6 +18,7 @@ enum BackendProcessType: String, Sendable {
     case lmStudio = "lm_studio"
     case mlxLM = "mlx_lm"
     case omlx
+    case mtplx
     case vllm = "vllm"
     case localAI = "local_ai"
     case llamaServer = "llama_server"
@@ -103,6 +104,8 @@ actor ProcessMonitor {
         // below, but keep it ahead so the more specific label always wins.
         ({ $0.lowercased().contains("omlx") },
          .omlx, "oMLX"),
+        ({ $0.lowercased().contains("mtplx") },
+         .mtplx, "MTPLX"),
         ({ $0.contains("mlx_lm") || $0.contains("mlx-lm") || $0.hasSuffix("/mlx_lm.server") },
          .mlxLM, "mlx-lm"),
         ({ $0.hasSuffix("/vllm") || $0.contains("vllm.entrypoints") },
@@ -116,6 +119,7 @@ actor ProcessMonitor {
     /// Python-based backends detected via command-line arguments
     private static let pythonPatterns: [(argCheck: (String) -> Bool, type: BackendProcessType, name: String)] = [
         ({ $0.lowercased().contains("omlx") }, .omlx, "oMLX"),
+        ({ $0.lowercased().contains("mtplx") }, .mtplx, "MTPLX"),
         ({ $0.contains("mlx_lm") || $0.contains("mlx-lm") }, .mlxLM, "mlx-lm"),
         ({ $0.contains("vllm") }, .vllm, "vLLM"),
         ({ $0.contains("tabbyAPI") || $0.contains("tabby_api") }, .unknown, "TabbyAPI"),
@@ -193,8 +197,8 @@ actor ProcessMonitor {
             return match
         }
 
-        // Default priority: Ollama > LM Studio > llama-server > oMLX > mlx-lm > vLLM > LocalAI
-        let priority: [BackendProcessType] = [.ollama, .lmStudio, .llamaServer, .omlx, .mlxLM, .vllm, .localAI]
+        // Default priority: Ollama > LM Studio > llama-server > MTPLX > oMLX > mlx-lm > vLLM > LocalAI
+        let priority: [BackendProcessType] = [.ollama, .lmStudio, .llamaServer, .mtplx, .omlx, .mlxLM, .vllm, .localAI]
         for type in priority {
             if let match = backends.first(where: { $0.type == type }) {
                 primaryBackend = match

--- a/anubis/anubis/Models/BackendConfiguration.swift
+++ b/anubis/anubis/Models/BackendConfiguration.swift
@@ -97,13 +97,26 @@ struct BackendConfiguration: Identifiable, Codable, Hashable {
         isEnabled: true
     )
 
+    /// Default MTPLX configuration (mtplx.com).
+    /// MTPLX exposes an OpenAI-compatible API on port 8000 and identifies its
+    /// models with `owned_by: "mtplx"`. OpenAICompatibleClient also consumes
+    /// its `mtplx_stats` response extension for server-measured benchmark data.
+    static let defaultMTPLX = BackendConfiguration(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000006")!,
+        name: "MTPLX",
+        type: .openaiCompatible,
+        baseURL: "http://localhost:8000",
+        isEnabled: true
+    )
+
     /// IDs of built-in default configurations that cannot be deleted
     static let defaultIDs: Set<UUID> = [
         defaultOllama.id,
         defaultMLX.id,
         defaultLMStudio.id,
         defaultVLLM.id,
-        defaultOMLX.id
+        defaultOMLX.id,
+        defaultMTPLX.id
     ]
 }
 
@@ -122,7 +135,8 @@ class BackendConfigurationManager: ObservableObject {
         .defaultMLX,
         .defaultLMStudio,
         .defaultVLLM,
-        .defaultOMLX
+        .defaultOMLX,
+        .defaultMTPLX
     ]
 
     init() {

--- a/anubis/anubis/Models/BenchmarkSession.swift
+++ b/anubis/anubis/Models/BenchmarkSession.swift
@@ -72,9 +72,9 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
     // step fires inside a flow.
     var flowRunId: Int64?
 
-    // v11: the backend's raw `usage` object as JSON, captured verbatim when
-    // the server reports its own metrics (oMLX). NULL for every other backend.
-    // Surfaced in the Inference Stats popover so oMLX's numbers display exactly
+    // v11: the backend's raw metrics object as JSON, captured verbatim when
+    // the server reports its own metrics (oMLX/MTPLX). NULL for other backends.
+    // Surfaced in the Inference Stats popover so the server's numbers display exactly
     // as the server sent them.
     var serverMetricsJSON: String?
 

--- a/anubis/anubis/Models/InferenceChunk.swift
+++ b/anubis/anubis/Models/InferenceChunk.swift
@@ -64,22 +64,22 @@ struct InferenceStats: Sendable, Codable {
     let reasoningDuration: TimeInterval
 
     /// Backend-reported generation throughput (tok/s), when the server measures
-    /// it itself inside the decode loop (oMLX). Preferred over our wall-clock
+    /// it itself inside the decode loop (oMLX/MTPLX). Preferred over our wall-clock
     /// derivation, which a bursty SSE reader can inflate wildly (issue #25).
     /// nil for backends that report only token counts (mlx-lm, LM Studio, ...).
     let reportedTokensPerSecond: Double?
 
-    /// Backend-reported time-to-first-token in seconds (oMLX). nil otherwise,
+    /// Backend-reported time-to-first-token in seconds (oMLX/MTPLX). nil otherwise,
     /// in which case the ViewModel uses its own first-chunk wall-clock timing.
     let serverReportedTTFT: TimeInterval?
 
-    /// Backend-reported prompt (prefill) throughput in tok/s (oMLX). Preferred
+    /// Backend-reported prompt (prefill) throughput in tok/s (oMLX/MTPLX). Preferred
     /// over deriving prompt_tokens / prompt_eval_duration, which rounds slightly
     /// differently from the backend's own figure. nil for other servers.
     let reportedPromptTokensPerSecond: Double?
 
-    /// The backend's raw `usage` object as a JSON string, captured verbatim
-    /// when it reports its own metrics (oMLX). Lets the UI display every field
+    /// The backend's raw metrics object as a JSON string, captured verbatim
+    /// when it reports its own metrics (oMLX/MTPLX). Lets the UI display every field
     /// exactly as the server sent it, including ones we don't model. nil
     /// for backends that report only standard token counts.
     let serverReportedMetricsJSON: String?
@@ -151,7 +151,7 @@ struct InferenceStats: Sendable, Codable {
     /// something meaningful instead of a spurious zero.
     var tokensPerSecond: Double {
         // Trust the backend's own decode-loop measurement when it provides one
-        // (oMLX). It can't be corrupted by client-side read bursts the way our
+        // (oMLX/MTPLX). It can't be corrupted by client-side read bursts the way our
         // wall-clock derivation can (issue #25).
         if let reported = reportedTokensPerSecond, reported > 0 {
             return reported
@@ -190,7 +190,7 @@ struct InferenceStats: Sendable, Codable {
 
     /// Prompt processing speed — input tokens/sec (prefill speed).
     var promptProcessingSpeed: Double {
-        // Trust the backend's own prefill rate when it reports one (oMLX).
+        // Trust the backend's own prefill rate when it reports one (oMLX/MTPLX).
         if let reported = reportedPromptTokensPerSecond, reported > 0 {
             return reported
         }

--- a/anubis/anubis/Models/ModelInfo.swift
+++ b/anubis/anubis/Models/ModelInfo.swift
@@ -74,9 +74,10 @@ struct ModelInfo: Identifiable, Hashable, Codable {
     let modifiedAt: Date?
 
     /// The `owned_by` field from an OpenAI-compatible `/v1/models` listing.
-    /// oMLX stamps every model with `owned_by: "omlx"`, which we use as a
-    /// connect-time identity fingerprint (another server squatting on the
-    /// oMLX port won't claim this). nil when the server doesn't report it.
+    /// oMLX and MTPLX stamp their models with distinct values, which we use as
+    /// connect-time identity fingerprints (another server sharing port 8000
+    /// won't accidentally enable their server-specific behavior). nil when
+    /// the server doesn't report it.
     var ownedBy: String? = nil
 
     /// Formatted size for display

--- a/anubis/anubisTests/anubisTests.swift
+++ b/anubis/anubisTests/anubisTests.swift
@@ -5,13 +5,45 @@
 //  Created by J T on 1/25/26.
 //
 
+import Foundation
 import Testing
 @testable import anubis
 
 struct anubisTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func mtplxDefaultConfiguration() {
+        let config = BackendConfiguration.defaultMTPLX
+
+        #expect(config.name == "MTPLX")
+        #expect(config.type == .openaiCompatible)
+        #expect(config.baseURL == "http://localhost:8000")
+        #expect(config.isEnabled)
+        #expect(BackendConfiguration.defaultIDs.contains(config.id))
+    }
+
+    @Test @MainActor func mtplxServerTimingDecoding() throws {
+        let json = #"""
+        {
+            "elapsed_s": 2.75,
+            "request_elapsed_s": 2.9,
+            "prompt_eval_time_s": 0.4,
+            "prompt_tps": 125.5,
+            "ttft_s": 0.45,
+            "decode_elapsed_s": 2.35,
+            "decode_tok_s": 54.25
+        }
+        """#
+        let data = try #require(json.data(using: .utf8))
+
+        let stats = try JSONDecoder().decode(MTPLXStats.self, from: data)
+
+        #expect(stats.requestElapsed == 2.9)
+        #expect(stats.promptEvalTime == 0.4)
+        #expect(stats.promptTokensPerSecond == 125.5)
+        #expect(stats.timeToFirstToken == 0.45)
+        #expect(stats.decodeElapsed == 2.35)
+        #expect(stats.decodeTokensPerSecond == 54.25)
+        #expect(stats.hasServerTiming)
     }
 
 }


### PR DESCRIPTION
## Summary

- add a built-in MTPLX OpenAI-compatible backend and migrate it into existing configurations
- identify MTPLX models and processes, support its thinking request field, and capture native mtplx_stats timing
- show server-reported MTPLX metrics in benchmark details and history, with coverage for configuration and metrics decoding

## Testing

- xcodebuild with code signing disabled and the unrelated Metal stress-test shader excluded
- focused anubisTests test target (2 tests passed)