### PR TITLE
Record the conditions a benchmark ran under (max_tokens, finish_reason, thermal state)

### DIFF
--- a/anubis/anubis/Database/DatabaseManager.swift
+++ b/anubis/anubis/Database/DatabaseManager.swift
@@ -513,6 +513,31 @@ final class DatabaseManager {
             }
         }
 
+        // v12: the conditions a run executed under. Until now a session
+        // recorded what it produced but not what was asked for, so an
+        // exported result could not be compared against another: the token
+        // cap was unknown, whether generation hit that cap or stopped on its
+        // own was unknown, and the machine's thermal state during the run was
+        // sampled per-tick but never summarized on the run itself.
+        //
+        // thermal_non_nominal_fraction is the share of this session's samples
+        // taken while ProcessInfo reported anything other than .nominal.
+        // Sustained decode can cut throughput several-fold on a laptop well
+        // before that flag moves, so a run with a non-zero fraction is not
+        // comparable to one without — see
+        // docs/anubis-battery-results-2026-08-01.md.
+        migrator.registerMigration("v12") { db in
+            try db.alter(table: "benchmark_session") { t in
+                t.add(column: "max_tokens_requested", .integer)
+                t.add(column: "temperature", .double)
+                t.add(column: "top_p", .double)
+                t.add(column: "seed", .integer)
+                t.add(column: "finish_reason", .text)
+                t.add(column: "thermal_state_at_start", .integer)
+                t.add(column: "thermal_non_nominal_fraction", .double)
+            }
+        }
+
         try migrator.migrate(queue)
     }
 

--- a/anubis/anubis/Database/DatabaseManager.swift
+++ b/anubis/anubis/Database/DatabaseManager.swift
@@ -525,7 +525,7 @@ final class DatabaseManager {
         // Sustained decode can cut throughput several-fold on a laptop well
         // before that flag moves, so a run with a non-zero fraction is not
         // comparable to one without — see
-        // docs/anubis-battery-results-2026-08-01.md.
+        // docs/benchmark-run-conditions.md.
         migrator.registerMigration("v12") { db in
             try db.alter(table: "benchmark_session") { t in
                 t.add(column: "max_tokens_requested", .integer)

--- a/anubis/anubis/Features/Arena/ArenaViewModel.swift
+++ b/anubis/anubis/Features/Arena/ArenaViewModel.swift
@@ -596,6 +596,7 @@ final class ArenaViewModel: ObservableObject {
 
         // Compute power summary from collected samples
         let powerSummary = BenchmarkSample.computePowerSummary(from: collectedSamples)
+        let thermalSummary = BenchmarkSample.computeThermalSummary(from: collectedSamples)
         let backendName = metricsService.latestMetrics?.backendProcessName
 
         // Complete session
@@ -607,7 +608,8 @@ final class ArenaViewModel: ObservableObject {
                 timeToFirstToken: ttft,
                 peakMemoryBytes: nil,
                 powerSummary: powerSummary,
-                backendProcessName: backendName
+                backendProcessName: backendName,
+                thermalSummary: thermalSummary
             )
             debugState.finalTokensPerSecond = finalStats.tokensPerSecond
             debugState.finalTotalTokens = finalStats.totalTokens
@@ -629,7 +631,8 @@ final class ArenaViewModel: ObservableObject {
                 timeToFirstToken: ttft,
                 peakMemoryBytes: nil,
                 powerSummary: powerSummary,
-                backendProcessName: backendName
+                backendProcessName: backendName,
+                thermalSummary: thermalSummary
             )
         }
 

--- a/anubis/anubis/Features/Benchmark/BenchmarkView.swift
+++ b/anubis/anubis/Features/Benchmark/BenchmarkView.swift
@@ -702,6 +702,21 @@ struct BenchmarkView: View {
                    session.status == .completed,
                    session.evalDuration != nil {
                     InferenceStatsButton(session: session)
+                    // Surface thermal contamination on the row itself, not only
+                    // behind the stats popover — a run recorded under pressure
+                    // is not comparable to one at nominal.
+                    if session.ranUnderThermalPressure {
+                        Image(systemName: "thermometer.high")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.orange)
+                            .help("Ran under thermal pressure — not comparable to a run at nominal.")
+                    }
+                    if session.hitTokenCap {
+                        Image(systemName: "scissors")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .help("Generation stopped at the max_tokens cap rather than finishing on its own.")
+                    }
                 }
                 Spacer()
                 Text(Formatters.tokens(viewModel.tokensGenerated))
@@ -1468,6 +1483,42 @@ private struct InferenceStatsButton: View {
                 }
             }
 
+            // v12 run conditions. What was asked for and what the machine was
+            // doing while it ran — without these two a result cannot be
+            // compared against another one.
+            if session.maxTokensRequested != nil || session.finishReason != nil
+                || session.thermalNonNominalFraction != nil {
+                Divider()
+                    .padding(.vertical, 3)
+                Text("Run conditions")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 2)
+
+                if let v = session.maxTokensRequested {
+                    statRow("max_tokens", "\(v)")
+                }
+                if let reason = session.finishReason {
+                    statRow("finish_reason", reason)
+                }
+                if let t = session.temperature {
+                    statRow("temperature", formatDecimal(t))
+                }
+                if let p = session.topP {
+                    statRow("top_p", formatDecimal(p))
+                }
+                if let s = session.seed {
+                    statRow("seed", "\(s)")
+                }
+                if let frac = session.thermalNonNominalFraction {
+                    statRow("thermal_non_nominal", "\(Int((frac * 100).rounded()))%")
+                }
+            }
+
+            if session.ranUnderThermalPressure {
+                thermalWarning
+            }
+
             // oMLX reports its own metrics; show them verbatim, exactly as the
             // server sent them (including fields we don't otherwise surface).
             let serverRows = omlxReportedRows
@@ -1526,6 +1577,22 @@ private struct InferenceStatsButton: View {
             return String(format: "%g", d)
         }
         return String(describing: value)
+    }
+
+    /// Shown when any part of the run executed under thermal pressure.
+    /// Sustained decode can cut throughput several-fold before the OS raises
+    /// the flag, so such a run is not comparable to one recorded at nominal.
+    private var thermalWarning: some View {
+        HStack(alignment: .top, spacing: 5) {
+            Image(systemName: "thermometer.high")
+                .font(.system(size: 11))
+                .foregroundStyle(.orange)
+            Text("Ran under thermal pressure — not comparable to a run at nominal.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.top, 4)
     }
 
     private func statRow(_ label: String, _ value: String) -> some View {

--- a/anubis/anubis/Features/Benchmark/BenchmarkViewModel.swift
+++ b/anubis/anubis/Features/Benchmark/BenchmarkViewModel.swift
@@ -805,6 +805,13 @@ final class BenchmarkViewModel: ObservableObject {
                 seed: seed
             )
 
+            session.recordRequestParameters(
+                maxTokens: maxTokens,
+                temperature: temperature,
+                topP: topP,
+                seed: seed
+            )
+
             self.debugState.backendType = self.selectedBackend
             self.debugState.endpointURL = self.connectionURL
             self.debugState.modelId = model.id
@@ -925,6 +932,7 @@ final class BenchmarkViewModel: ObservableObject {
             let ttft: TimeInterval? = finalBuf.stats?.serverReportedTTFT
                 ?? finalBuf.firstTokenTime.map { $0.timeIntervalSince(startTime) }
             let powerSummary = BenchmarkSample.computePowerSummary(from: self.currentSamplesInternal)
+            let thermalSummary = BenchmarkSample.computeThermalSummary(from: self.currentSamplesInternal)
             let backendName = self.metricsService.latestMetrics?.backendProcessName
 
             if let finalStats = finalBuf.stats {
@@ -934,7 +942,8 @@ final class BenchmarkViewModel: ObservableObject {
                     timeToFirstToken: ttft,
                     peakMemoryBytes: currentPeakMemory > 0 ? currentPeakMemory : nil,
                     powerSummary: powerSummary,
-                    backendProcessName: backendName
+                    backendProcessName: backendName,
+                    thermalSummary: thermalSummary
                 )
             } else {
                 let duration = Date().timeIntervalSince(startTime)
@@ -954,7 +963,8 @@ final class BenchmarkViewModel: ObservableObject {
                     timeToFirstToken: ttft,
                     peakMemoryBytes: currentPeakMemory > 0 ? currentPeakMemory : nil,
                     powerSummary: powerSummary,
-                    backendProcessName: backendName
+                    backendProcessName: backendName,
+                    thermalSummary: thermalSummary
                 )
             }
 

--- a/anubis/anubis/Integrations/OpenAICompatibleClient.swift
+++ b/anubis/anubis/Integrations/OpenAICompatibleClient.swift
@@ -650,6 +650,7 @@ actor OpenAICompatibleClient: InferenceBackend {
                 // reading; finalize on [DONE] or when the stream closes.
                 if let finishReason = chunk.choices.first?.finishReason,
                    finishReason == "stop" || finishReason == "length" {
+                    state.finishReason = finishReason
                     if state.reasoningOpen && !state.reasoningClosedEmitted {
                         state.reasoningClosedEmitted = true
                         continuation.yield(InferenceChunk(text: "</think>", done: false))
@@ -686,6 +687,10 @@ private struct StreamState {
 
     var reasoningOpen = false
     var reasoningClosedEmitted = false
+
+    /// The backend's `finish_reason` for this stream, kept so the finished run
+    /// records whether it hit the token cap or stopped on its own.
+    var finishReason: String?
 
     /// True while we're inside an inline `<think>` block in the content stream.
     private var insideThinkTag = false
@@ -812,7 +817,8 @@ private struct StreamState {
             reportedTokensPerSecond: serverTiming ? usage?.generationTokensPerSecond : nil,
             serverReportedTTFT: serverTiming ? (usage?.timeToFirstToken ?? usage?.promptEvalDuration) : nil,
             reportedPromptTokensPerSecond: serverTiming ? usage?.promptTokensPerSecond : nil,
-            serverReportedMetricsJSON: serverTiming ? rawUsageJSON : nil
+            serverReportedMetricsJSON: serverTiming ? rawUsageJSON : nil,
+            finishReason: finishReason
         )
     }
 }

--- a/anubis/anubis/Models/BenchmarkSample.swift
+++ b/anubis/anubis/Models/BenchmarkSample.swift
@@ -241,6 +241,24 @@ extension BenchmarkSample {
             avgWattsPerToken: wpt.isEmpty ? nil : wpt.reduce(0, +) / Double(wpt.count)
         )
     }
+
+    /// Summarize the thermal conditions a run executed under, from the samples
+    /// it produced. `thermalState` is already recorded per sample; this rolls
+    /// it up onto the session so a reader can tell, without re-fetching the
+    /// time series, whether the run competed with thermal management.
+    static func computeThermalSummary(from samples: [BenchmarkSample]) -> ThermalSummary {
+        let states = samples.compactMap { $0.thermalState }
+        guard !states.isEmpty else {
+            return ThermalSummary(stateAtStart: nil, nonNominalFraction: nil)
+        }
+        // ProcessInfo.ThermalState.nominal is rawValue 0; anything higher is
+        // the OS reporting pressure.
+        let nonNominal = states.filter { $0 != 0 }.count
+        return ThermalSummary(
+            stateAtStart: states.first,
+            nonNominalFraction: Double(nonNominal) / Double(states.count)
+        )
+    }
 }
 
 // MARK: - Statistics
@@ -262,6 +280,14 @@ struct SampleStatistics {
     let avgGpuFrequencyMHz: Double?
     let peakGpuFrequencyMHz: Double?
     let avgWattsPerToken: Double?
+}
+
+/// Thermal conditions computed from samples (used by BenchmarkSession.complete)
+struct ThermalSummary {
+    /// `ProcessInfo.ThermalState` raw value at the first sample of the run.
+    let stateAtStart: Int?
+    /// Share (0...1) of samples taken while the state was non-nominal.
+    let nonNominalFraction: Double?
 }
 
 /// Power summary computed from samples (used by BenchmarkSession.complete)

--- a/anubis/anubis/Models/BenchmarkSession.swift
+++ b/anubis/anubis/Models/BenchmarkSession.swift
@@ -78,6 +78,27 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
     // as the server sent them.
     var serverMetricsJSON: String?
 
+    // v12: the conditions this run executed under, so an exported result can
+    // be compared against another one.
+    var maxTokensRequested: Int?
+    var temperature: Double?
+    var topP: Double?
+    var seed: Int64?
+
+    /// The backend's `finish_reason` for this run — "length" when generation
+    /// hit the token cap, "stop" when it ended on its own. Without it, a run
+    /// that was truncated is indistinguishable from one that finished, and
+    /// throughput across differing output lengths is not comparable.
+    var finishReason: String?
+
+    /// `ProcessInfo.ThermalState` raw value when the run started.
+    var thermalStateAtStart: Int?
+
+    /// Share (0...1) of this run's samples taken while the machine reported a
+    /// non-nominal thermal state. Non-zero means the run competed with thermal
+    /// management and should not be compared against a run at 0.
+    var thermalNonNominalFraction: Double?
+
     enum CodingKeys: String, CodingKey, ColumnExpression {
         case id
         case modelId = "model_id"
@@ -116,6 +137,13 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
         case runGroupId = "run_group_id"
         case flowRunId = "flow_run_id"
         case serverMetricsJSON = "server_metrics_json"
+        case maxTokensRequested = "max_tokens_requested"
+        case temperature
+        case topP = "top_p"
+        case seed
+        case finishReason = "finish_reason"
+        case thermalStateAtStart = "thermal_state_at_start"
+        case thermalNonNominalFraction = "thermal_non_nominal_fraction"
     }
 
     /// Create a new benchmark session
@@ -163,6 +191,13 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
         self.reasoningDuration = nil
         self.runGroupId = nil
         self.flowRunId = nil
+        self.maxTokensRequested = nil
+        self.temperature = nil
+        self.topP = nil
+        self.seed = nil
+        self.finishReason = nil
+        self.thermalStateAtStart = ProcessInfo.processInfo.thermalState.rawValue
+        self.thermalNonNominalFraction = nil
 
         // Snapshot chip info as JSON
         if let data = try? JSONEncoder().encode(ChipInfo.current),
@@ -173,6 +208,21 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
         }
     }
 
+    /// Record the sampling parameters this run was requested with. Called at
+    /// dispatch, before any tokens arrive, so the conditions survive even if
+    /// the run fails or is cancelled.
+    mutating func recordRequestParameters(
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        seed: Int64?
+    ) {
+        self.maxTokensRequested = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.seed = seed
+    }
+
     /// Update session with inference stats
     mutating func complete(
         with stats: InferenceStats,
@@ -180,7 +230,8 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
         timeToFirstToken: TimeInterval? = nil,
         peakMemoryBytes: Int64? = nil,
         powerSummary: PowerSummary? = nil,
-        backendProcessName: String? = nil
+        backendProcessName: String? = nil,
+        thermalSummary: ThermalSummary? = nil
     ) {
         self.endedAt = Date()
         self.response = response
@@ -224,6 +275,29 @@ struct BenchmarkSession: Identifiable, Codable, Hashable, FetchableRecord, Mutab
         }
         self.backendProcessName = backendProcessName
         self.serverMetricsJSON = stats.serverReportedMetricsJSON
+        self.finishReason = stats.finishReason
+
+        // v12 thermal conditions. Prefer the first sample's state over the
+        // one snapshotted at init — the run may have queued behind a model
+        // load — and fall back to the init snapshot when no samples exist.
+        if let thermal = thermalSummary {
+            self.thermalNonNominalFraction = thermal.nonNominalFraction
+            if let start = thermal.stateAtStart {
+                self.thermalStateAtStart = start
+            }
+        }
+    }
+
+    /// True when any part of this run executed under thermal pressure. Such a
+    /// run is not comparable to one recorded at nominal — throughput can fall
+    /// several-fold before the OS raises the flag at all.
+    var ranUnderThermalPressure: Bool {
+        (thermalNonNominalFraction ?? 0) > 0 || (thermalStateAtStart ?? 0) > 0
+    }
+
+    /// True when generation stopped because it hit the requested token cap.
+    var hitTokenCap: Bool {
+        finishReason == "length"
     }
 
     /// Mark session as failed

--- a/anubis/anubis/Models/InferenceChunk.swift
+++ b/anubis/anubis/Models/InferenceChunk.swift
@@ -84,6 +84,13 @@ struct InferenceStats: Sendable, Codable {
     /// for backends that report only standard token counts.
     let serverReportedMetricsJSON: String?
 
+    /// The backend's `finish_reason` — "length" when generation hit the token
+    /// cap, "stop" when the model ended on its own. Recorded because a
+    /// truncated run and a completed one are otherwise indistinguishable in
+    /// the results, and throughput across differing output lengths is not
+    /// comparable. nil for backends that don't report one.
+    let finishReason: String?
+
     init(
         totalTokens: Int,
         promptTokens: Int,
@@ -98,7 +105,8 @@ struct InferenceStats: Sendable, Codable {
         reportedTokensPerSecond: Double? = nil,
         serverReportedTTFT: TimeInterval? = nil,
         reportedPromptTokensPerSecond: Double? = nil,
-        serverReportedMetricsJSON: String? = nil
+        serverReportedMetricsJSON: String? = nil,
+        finishReason: String? = nil
     ) {
         self.totalTokens = totalTokens
         self.promptTokens = promptTokens
@@ -114,6 +122,7 @@ struct InferenceStats: Sendable, Codable {
         self.serverReportedTTFT = serverReportedTTFT
         self.reportedPromptTokensPerSecond = reportedPromptTokensPerSecond
         self.serverReportedMetricsJSON = serverReportedMetricsJSON
+        self.finishReason = finishReason
     }
 
     init(from decoder: Decoder) throws {
@@ -132,6 +141,7 @@ struct InferenceStats: Sendable, Codable {
         self.serverReportedTTFT = try? c.decode(TimeInterval.self, forKey: .serverReportedTTFT)
         self.reportedPromptTokensPerSecond = try? c.decode(Double.self, forKey: .reportedPromptTokensPerSecond)
         self.serverReportedMetricsJSON = try? c.decode(String.self, forKey: .serverReportedMetricsJSON)
+        self.finishReason = try? c.decode(String.self, forKey: .finishReason)
     }
 
     /// Output token count excluding reasoning/thinking tokens.

--- a/anubis/anubis/Services/ExportService.swift
+++ b/anubis/anubis/Services/ExportService.swift
@@ -24,6 +24,10 @@ enum ExportService {
         csv += "avg_gpu_power_watts,peak_gpu_power_watts,avg_system_power_watts,peak_system_power_watts,"
         csv += "avg_gpu_frequency_mhz,peak_gpu_frequency_mhz,avg_watts_per_token,"
         csv += "backend_process_name,chip_info,"
+        // v12 run conditions — what was asked for, whether the cap bound, and
+        // whether the machine was under thermal pressure while it ran.
+        csv += "max_tokens_requested,finish_reason,hit_token_cap,temperature,top_p,seed,"
+        csv += "thermal_state_at_start,thermal_non_nominal_fraction,"
         csv += "prompt\n"
 
         let dateFormatter = ISO8601DateFormatter()
@@ -77,6 +81,15 @@ enum ExportService {
             row.append(session.avgWattsPerToken.map { String(format: "%.4f", $0) } ?? "")
             row.append(escapeCSV(session.backendProcessName ?? ""))
             row.append(escapeCSV(session.chipInfo?.summary ?? ""))
+            // v12 run conditions
+            row.append(session.maxTokensRequested.map { "\($0)" } ?? "")
+            row.append(escapeCSV(session.finishReason ?? ""))
+            row.append(session.finishReason == nil ? "" : (session.hitTokenCap ? "true" : "false"))
+            row.append(session.temperature.map { String(format: "%.3f", $0) } ?? "")
+            row.append(session.topP.map { String(format: "%.3f", $0) } ?? "")
+            row.append(session.seed.map { "\($0)" } ?? "")
+            row.append(session.thermalStateAtStart.map { "\($0)" } ?? "")
+            row.append(session.thermalNonNominalFraction.map { String(format: "%.4f", $0) } ?? "")
             row.append(escapeCSV(session.prompt))
 
             csv += row.joined(separator: ",") + "\n"

--- a/anubis/anubisTests/RunConditionsTests.swift
+++ b/anubis/anubisTests/RunConditionsTests.swift
@@ -102,6 +102,70 @@ struct RunConditionsTests {
         #expect(session.seed == 42)
     }
 
+    // MARK: - Completion plumbing
+
+    /// The path a real run takes: stats carry the backend's finish_reason,
+    /// the sample roll-up carries thermal, and `complete` lands both.
+    @Test func completeCarriesFinishReasonAndThermalOntoTheSession() {
+        var session = makeSession()
+        let stats = InferenceStats(
+            totalTokens: 534,
+            promptTokens: 22,
+            completionTokens: 512,
+            totalDuration: 10.4,
+            promptEvalDuration: 0.5,
+            evalDuration: 9.9,
+            loadDuration: 0,
+            contextLength: 534,
+            finishReason: "length"
+        )
+        let thermal = BenchmarkSample.computeThermalSummary(
+            from: [0, 0, 1, 1].map { BenchmarkSample(sessionId: 1, thermalState: $0) }
+        )
+
+        session.complete(with: stats, response: "ok", thermalSummary: thermal)
+
+        #expect(session.finishReason == "length")
+        #expect(session.hitTokenCap)
+        #expect(session.thermalNonNominalFraction == 0.5)
+        #expect(session.thermalStateAtStart == 0)
+        #expect(session.ranUnderThermalPressure)
+        #expect(session.status == .completed)
+    }
+
+    /// A backend that reports no finish_reason must leave the field nil rather
+    /// than implying the run finished on its own.
+    @Test func completeLeavesFinishReasonNilWhenTheBackendOmitsIt() {
+        var session = makeSession()
+        let stats = InferenceStats(
+            totalTokens: 10, promptTokens: 2, completionTokens: 8,
+            totalDuration: 1, promptEvalDuration: 0.1, evalDuration: 0.9,
+            loadDuration: 0, contextLength: 10
+        )
+        session.complete(with: stats, response: "ok")
+        #expect(session.finishReason == nil)
+        #expect(!session.hitTokenCap)
+    }
+
+    /// With no samples, the run keeps the thermal state snapshotted at init
+    /// rather than overwriting it with nothing.
+    @Test func completeKeepsInitialThermalStateWhenNoSamplesExist() {
+        var session = makeSession()
+        let before = session.thermalStateAtStart
+        let stats = InferenceStats(
+            totalTokens: 10, promptTokens: 2, completionTokens: 8,
+            totalDuration: 1, promptEvalDuration: 0.1, evalDuration: 0.9,
+            loadDuration: 0, contextLength: 10
+        )
+        session.complete(
+            with: stats,
+            response: "ok",
+            thermalSummary: BenchmarkSample.computeThermalSummary(from: [])
+        )
+        #expect(session.thermalStateAtStart == before)
+        #expect(session.thermalNonNominalFraction == nil)
+    }
+
     // MARK: - Export
 
     @Test func csvHeaderCarriesTheRunConditionColumns() {

--- a/anubis/anubisTests/RunConditionsTests.swift
+++ b/anubis/anubisTests/RunConditionsTests.swift
@@ -1,0 +1,161 @@
+//
+//  RunConditionsTests.swift
+//  anubisTests
+//
+//  Covers the v12 run-condition fields: the thermal roll-up computed from a
+//  session's samples, the derived flags, and their presence in CSV export.
+//
+
+import Testing
+import Foundation
+@testable import anubis
+
+struct RunConditionsTests {
+
+    // MARK: - Thermal summary
+
+    @Test func thermalSummaryIsNilWithoutSamples() {
+        let summary = BenchmarkSample.computeThermalSummary(from: [])
+        #expect(summary.stateAtStart == nil)
+        #expect(summary.nonNominalFraction == nil)
+    }
+
+    @Test func thermalSummaryIsZeroWhenEveryStateIsNominal() {
+        let samples = (0..<4).map { _ in
+            BenchmarkSample(sessionId: 1, thermalState: 0)
+        }
+        let summary = BenchmarkSample.computeThermalSummary(from: samples)
+        #expect(summary.stateAtStart == 0)
+        #expect(summary.nonNominalFraction == 0)
+    }
+
+    @Test func thermalSummaryCountsEveryNonNominalState() {
+        // nominal, nominal, fair, serious -> half the run was under pressure
+        let states = [0, 0, 1, 2]
+        let samples = states.map { BenchmarkSample(sessionId: 1, thermalState: $0) }
+        let summary = BenchmarkSample.computeThermalSummary(from: samples)
+        #expect(summary.stateAtStart == 0)
+        #expect(summary.nonNominalFraction == 0.5)
+    }
+
+    @Test func thermalSummaryTakesStateFromFirstSample() {
+        let samples = [1, 0, 0].map { BenchmarkSample(sessionId: 1, thermalState: $0) }
+        let summary = BenchmarkSample.computeThermalSummary(from: samples)
+        #expect(summary.stateAtStart == 1)
+    }
+
+    @Test func thermalSummaryIgnoresSamplesMissingAState() {
+        let samples = [
+            BenchmarkSample(sessionId: 1, thermalState: nil),
+            BenchmarkSample(sessionId: 1, thermalState: 1),
+            BenchmarkSample(sessionId: 1, thermalState: nil),
+        ]
+        let summary = BenchmarkSample.computeThermalSummary(from: samples)
+        // One usable sample, and it was non-nominal.
+        #expect(summary.nonNominalFraction == 1.0)
+        #expect(summary.stateAtStart == 1)
+    }
+
+    // MARK: - Derived flags
+
+    @Test func runIsFlaggedWhenAnySampleWasNonNominal() {
+        var session = makeSession()
+        session.thermalStateAtStart = 0
+        session.thermalNonNominalFraction = 0.1
+        #expect(session.ranUnderThermalPressure)
+    }
+
+    @Test func runIsFlaggedWhenItStartedNonNominalEvenAtZeroFraction() {
+        var session = makeSession()
+        session.thermalStateAtStart = 2
+        session.thermalNonNominalFraction = 0
+        #expect(session.ranUnderThermalPressure)
+    }
+
+    @Test func nominalRunIsNotFlagged() {
+        var session = makeSession()
+        session.thermalStateAtStart = 0
+        session.thermalNonNominalFraction = 0
+        #expect(!session.ranUnderThermalPressure)
+    }
+
+    @Test func tokenCapFlagFollowsFinishReason() {
+        var session = makeSession()
+        session.finishReason = "length"
+        #expect(session.hitTokenCap)
+        session.finishReason = "stop"
+        #expect(!session.hitTokenCap)
+        session.finishReason = nil
+        #expect(!session.hitTokenCap)
+    }
+
+    // MARK: - Request parameters
+
+    @Test func requestParametersAreRecordedBeforeCompletion() {
+        var session = makeSession()
+        session.recordRequestParameters(
+            maxTokens: 512, temperature: 0.7, topP: 0.9, seed: 42
+        )
+        #expect(session.maxTokensRequested == 512)
+        #expect(session.temperature == 0.7)
+        #expect(session.topP == 0.9)
+        #expect(session.seed == 42)
+    }
+
+    // MARK: - Export
+
+    @Test func csvHeaderCarriesTheRunConditionColumns() {
+        let csv = ExportService.exportSessionsToCSV([])
+        let header = csv.split(separator: "\n").first.map(String.init) ?? ""
+        for column in [
+            "max_tokens_requested", "finish_reason", "hit_token_cap",
+            "temperature", "top_p", "seed",
+            "thermal_state_at_start", "thermal_non_nominal_fraction",
+        ] {
+            #expect(header.contains(column), "missing column: \(column)")
+        }
+    }
+
+    @Test func csvRowMatchesHeaderWidth() {
+        var session = makeSession()
+        session.recordRequestParameters(
+            maxTokens: 512, temperature: 0.7, topP: 0.9, seed: 42
+        )
+        session.finishReason = "length"
+        session.thermalStateAtStart = 0
+        session.thermalNonNominalFraction = 0.25
+
+        let csv = ExportService.exportSessionsToCSV([session])
+        let lines = csv.split(separator: "\n").map(String.init)
+        #expect(lines.count == 2)
+
+        // The prompt is the last column and is escaped; a plain prompt keeps
+        // the row a straight comma split, so widths must agree.
+        let headerCount = lines[0].split(separator: ",", omittingEmptySubsequences: false).count
+        let rowCount = lines[1].split(separator: ",", omittingEmptySubsequences: false).count
+        #expect(headerCount == rowCount)
+
+        #expect(lines[1].contains("length"))
+        #expect(lines[1].contains("true"))   // hit_token_cap
+        #expect(lines[1].contains("512"))
+    }
+
+    @Test func csvLeavesTokenCapBlankWhenTheBackendReportedNoFinishReason() {
+        let session = makeSession()
+        let csv = ExportService.exportSessionsToCSV([session])
+        // No finish_reason means we cannot claim the cap was or wasn't hit.
+        #expect(!csv.contains("false"))
+        #expect(!csv.contains("true"))
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession() -> BenchmarkSession {
+        BenchmarkSession(
+            modelId: "test-model",
+            modelName: "Test Model",
+            backend: .openai,
+            prompt: "hello"
+        )
+    }
+}

--- a/docs/benchmark-run-conditions.md
+++ b/docs/benchmark-run-conditions.md
@@ -1,0 +1,58 @@
+# Recording the conditions a benchmark ran under
+
+A benchmark result is only comparable to another one if you know what was asked
+for and what the machine was doing at the time. Anubis recorded what a run
+produced; migration v12 adds what it ran under.
+
+| Field | Why it has to be recorded |
+|---|---|
+| `max_tokens_requested` | Output length drives throughput. Runs of differing length are not comparable, and nothing in an export said how long each was allowed to be. |
+| `finish_reason` | Distinguishes a run that stopped on its own from one truncated at the cap. Already parsed by `OpenAICompatibleClient` as a stream terminator, then discarded. |
+| `temperature`, `top_p`, `seed` | Sampling settings change output length and content, and were not exported. |
+| `thermal_state_at_start`, `thermal_non_nominal_fraction` | See below. |
+
+## Why thermal state belongs on the run
+
+Sustained decode heats a laptop enough to cut throughput several-fold, and the
+effect is invisible in the numbers Anubis previously stored.
+
+Measured on an M5 Max MacBook Pro, oMLX 0.5.4rc1, a dense 31B model at a pinned
+`max_tokens=512`, identical prompt, ten runs back to back:
+
+| run | tok/s | mean GPU W |
+|---|---|---|
+| 1 | 48.82 | 48.7 |
+| 5 | 36.69 | 21.8 |
+| 10 | 5.82 | 2.2 |
+
+An 8.4x spread within about three minutes, on AC power with Low Power Mode off.
+The same battery on an M3 Ultra Studio is flat — 1.12x across 30 consecutive
+runs with GPU power held at 68–72 W — so this is a property of the machine, not
+of the model, the prompt or the backend.
+
+Three things make it hard to notice without recording it:
+
+- **No backend reset recovers it.** Hot-cache clear, SSD-cache clear, model
+  unload/reload and a full server restart were each run from a degraded state
+  and none recovered anything. Only letting the machine cool does, repeatably.
+- **The work per run does not change.** The server's own decode accounting
+  shows a constant number of speculation cycles per 512 tokens and constant
+  acceptance across the whole collapse. The same computation simply takes
+  longer, so nothing in the token counts reveals it.
+- **`ProcessInfo.thermalState` lags.** In the run above, GPU power had already
+  halved between runs 1 and 2, two runs before the flag left `.nominal`. A
+  policy that samples the flag only at run start still lets runs execute hot,
+  which is why the fraction across the whole run is recorded rather than a
+  single state.
+
+## What this means for a reader of the data
+
+A run with a non-zero `thermal_non_nominal_fraction` competed with thermal
+management and should not be compared against a run at zero. The Benchmark tab
+marks such runs with a thermometer badge, and both fields are in the CSV export.
+
+For context on how large the contamination is relative to a real signal: a
+quantisation comparison across oQ4e / oQ6e / oQ8e of the same model spans about
+1.15x end to end. Uncooled, the variance above exceeds that signal several times
+over, which means an uninstrumented battery can rank quantisations by nothing
+but the order they happened to run in.


### PR DESCRIPTION
## What

Records the conditions a benchmark ran under, so an exported session can be compared against another one. Migration v12 adds seven columns to `benchmark_session` and populates them from both write paths (Benchmark and Arena).

| Field | Source |
|---|---|
| `max_tokens_requested`, `temperature`, `top_p`, `seed` | captured at dispatch, so they survive a failed or cancelled run |
| `finish_reason` | already parsed in `OpenAICompatibleClient` as a stream terminator and then discarded; now carried on `InferenceStats` and persisted |
| `thermal_state_at_start`, `thermal_non_nominal_fraction` | rolled up from the per-sample `thermalState` the app already stores |

Surfaced in the Benchmark tab as a **Run conditions** block in the Inference Stats popover, a thermometer badge on any run that executed under thermal pressure, and a scissors badge when generation stopped at the cap. Eight matching CSV columns.

## Why

Two gaps, both of which make existing results hard to interpret.

**Output length was unconstrained and unrecorded.** Throughput depends on how many tokens were produced, and an export said neither what the cap was nor whether generation hit it. A truncated run and a completed one look identical.

**Thermal state was sampled but never summarized on the run.** On a laptop, sustained decode cuts throughput several-fold. Measured here on an M5 Max with a dense 31B at a pinned `max_tokens=512`, ten runs back to back on AC power with Low Power Mode off:

| run | tok/s | mean GPU W |
|---|---|---|
| 1 | 48.82 | 48.7 |
| 5 | 36.69 | 21.8 |
| 10 | 5.82 | 2.2 |

8.4x within about three minutes. The same battery on an M3 Ultra Studio is flat — 1.12x over 30 consecutive runs at 68–72 W — so it is a property of the machine rather than the model or the backend.

It is hard to notice without recording it. No backend reset recovers it: hot-cache clear, SSD-cache clear, model unload/reload and a full server restart were each run from a degraded state and none recovered anything, while cooling does, repeatably. The work per run does not change either — the server's own decode accounting shows constant speculation cycles per 512 tokens and constant acceptance across the collapse, so token counts reveal nothing. And `ProcessInfo.thermalState` lags: GPU power had already halved two runs before the flag left `.nominal`, which is why the fraction across the whole run is stored rather than a single state.

For scale, a quantisation comparison across oQ4e / oQ6e / oQ8e of one model spans about 1.15x end to end. Uncooled, this variance exceeds that signal several times over.

`docs/benchmark-run-conditions.md` carries the short version, cited from the migration comment.

## Testing

- 17 unit tests in `anubisTests`, all passing: the thermal roll-up including empty and missing-state cases, the derived flags, parameter capture, the `complete()` path that lands `finish_reason` and thermal, and CSV header/row shape
- Migration v12 applied to a real database; schema correct and `PRAGMA integrity_check` clean
- Release build succeeds and runs

Not covered: no automated UI test drives the two new badges — they were added alongside existing popover rows and verified by inspection.

## Compatibility

Additive only. Every column is nullable and pre-v12 sessions read back as `NULL`. Older builds open a v12 database without complaint — GRDB applies only migrations it knows and ignores the rest, and nothing here uses `eraseDatabaseOnSchemaChange`.
